### PR TITLE
Extended CacheTagHelper to utilize MVCCaching

### DIFF
--- a/Kentico13Core/XperienceCommunity.MVCCaching/Implementations/CacheRepositoryContext.cs
+++ b/Kentico13Core/XperienceCommunity.MVCCaching/Implementations/CacheRepositoryContext.cs
@@ -1,13 +1,11 @@
-﻿using CMS.Localization;
+﻿using CMS.DataEngine;
+using CMS.SiteProvider;
 using Kentico.Content.Web.Mvc;
 using Kentico.Web.Mvc;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using MVCCaching;
 using System;
-using CMS.DataEngine;
-using CMS.SiteProvider;
-using Kentico.PageBuilder.Web.Mvc;
 
 namespace XperienceCommunity.MVCCaching.Implementations
 {

--- a/Kentico13Core/XperienceCommunity.MVCCaching/Implementations/CacheRepositoryContext.cs
+++ b/Kentico13Core/XperienceCommunity.MVCCaching/Implementations/CacheRepositoryContext.cs
@@ -5,6 +5,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using MVCCaching;
 using System;
+using CMS.DataEngine;
+using CMS.SiteProvider;
+using Kentico.PageBuilder.Web.Mvc;
 
 namespace XperienceCommunity.MVCCaching.Implementations
 {
@@ -29,6 +32,21 @@ namespace XperienceCommunity.MVCCaching.Implementations
             } catch(Exception)
             {
                 return System.Globalization.CultureInfo.CurrentCulture.Name;
+            }
+        }
+
+        public int CacheTimeInMinutes()
+        {
+            try
+            {
+                var cacheTimeInMinutes =
+                    SettingsKeyInfoProvider.GetIntValue($"{SiteContext.CurrentSiteName}.CMSCacheMinutes");
+
+                return cacheTimeInMinutes;
+            }
+            catch (Exception)
+            {
+                return 0;
             }
         }
 

--- a/Kentico13Core/XperienceCommunity.MVCCaching/Interfaces/ICachingRepositoryContext.cs
+++ b/Kentico13Core/XperienceCommunity.MVCCaching/Interfaces/ICachingRepositoryContext.cs
@@ -5,5 +5,8 @@
         bool CacheEnabled();
         bool PreviewEnabled();
         string CurrentCulture();
+
+        int CacheTimeInMinutes();
+
     }
 }

--- a/Kentico13Core/XperienceCommunity.MVCCaching/TagHelpers/CacheScopeTagHelper.cs
+++ b/Kentico13Core/XperienceCommunity.MVCCaching/TagHelpers/CacheScopeTagHelper.cs
@@ -2,12 +2,11 @@
 using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Caching.Memory;
-using MVCCaching;
 using System;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 
-namespace XperienceCommunity.MVCCaching.TagHelpers
+namespace MVCCaching
 {
     [HtmlTargetElement("cache-scope")]
     public class CacheScopeTagHelper : CacheTagHelper

--- a/Kentico13Core/XperienceCommunity.MVCCaching/TagHelpers/CacheScopeTagHelper.cs
+++ b/Kentico13Core/XperienceCommunity.MVCCaching/TagHelpers/CacheScopeTagHelper.cs
@@ -1,0 +1,82 @@
+﻿using CMS.Helpers.Caching;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Caching.Memory;
+using MVCCaching;
+using System;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+
+namespace XperienceCommunity.MVCCaching.TagHelpers
+{
+    [HtmlTargetElement("cache-scope")]
+    public class CacheScopeTagHelper : CacheTagHelper
+    {
+        private readonly IMemoryCache mMemoryCache;
+        private readonly ICacheDependencyAdapter mCacheDependencyAdapter;
+        private readonly ICacheDependenciesScope mCacheDependenciesScope;
+        private readonly ICacheDependenciesStore mCacheDependenciesStore;
+        private readonly ICacheRepositoryContext mCacheRepositoryContext;
+
+
+        [HtmlAttributeName("additional-keys")]
+        public string[] AdditionalKeys { get; set; }
+
+        /// <inheritdoc />
+        public override void Init(TagHelperContext context)
+        {
+            base.Init(context);
+
+            mCacheDependenciesScope.Begin();
+
+            Enabled = mCacheRepositoryContext.CacheEnabled();
+
+            //sets cache time if not set by tag attribute to the Xperienece setting for system cache time in minutes
+            var cacheTimeInMinutes = mCacheRepositoryContext.CacheTimeInMinutes();
+            if (!ExpiresAfter.HasValue && cacheTimeInMinutes > 0)
+                ExpiresAfter = TimeSpan.FromMinutes(cacheTimeInMinutes);
+        }
+
+        /// <inheritdoc />
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            await base.ProcessAsync(context, output);
+
+            if (AdditionalKeys is not null)
+                mCacheDependenciesStore.Store(AdditionalKeys);
+
+            var cacheKeys = mCacheDependenciesScope.End();
+
+            if (!Enabled || cacheKeys is { Length: 0 })
+                return;
+
+            var changeToken = mCacheDependencyAdapter.GetChangeToken(cacheKeys);
+
+            var key = $"{Guid.NewGuid()}";
+            mMemoryCache.Set(key, (object)null, changeToken);
+            mMemoryCache.Remove(key);
+        }
+
+
+
+        public CacheScopeTagHelper(
+            CacheTagHelperMemoryCacheFactory factory,
+            HtmlEncoder htmlEncoder,
+            ICacheDependencyAdapter cacheDependencyAdapter,
+            ICacheDependenciesScope cacheDependenciesScope,
+            ICacheDependenciesStore cacheDependenciesStore,
+            ICacheRepositoryContext cacheRepositoryContext,
+            IMemoryCache memoryCache)
+            : base(factory, htmlEncoder)
+        {
+            mCacheDependencyAdapter = cacheDependencyAdapter;
+            mCacheDependenciesScope = cacheDependenciesScope;
+            mCacheDependenciesStore = cacheDependenciesStore;
+            mCacheRepositoryContext = cacheRepositoryContext;
+
+            //Using the shared MemoryCache from the factory cause size errors 
+            mMemoryCache = memoryCache;
+        }
+
+    }
+}

--- a/Kentico13Core/XperienceCommunity.MVCCaching/XperienceCommunity.MVCCaching.csproj
+++ b/Kentico13Core/XperienceCommunity.MVCCaching/XperienceCommunity.MVCCaching.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kentico.Xperience.AspNetCore.WebApp" Version="13.0.5" />
+    <PackageReference Include="Kentico.Xperience.AspNetCore.WebApp" Version="13.0.16" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.0" />
     <PackageReference Include="MVCCaching.Base.Core" Version="3.0.2" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -230,17 +230,17 @@ public class AlertsViewComponent : ViewComponent
 
 ```html 
 <!-- Will add scoped cache dependency keys -->
-<cache-scope>
+<cache scoped>
     <vc:alerts  />
-</cache-scope>
+</cache>
 <!-- Will add scoped cache dependency keys along with the additional keys passed -->
-<cache-scope additional-keys="@(new [] { $"{Alert.CLASS_NAME}|all" })">
+<cache scoped additional-keys="@(new [] { $"{Alert.CLASS_NAME}|all" })">
     <vc:alerts />
-</cache-scope>
+</cache>
 <!-- Will add scoped cache dependency keys along with the additional keys passed and override the expiresafter value from the system settings -->
-<cache-scope additional-keys="@(new [] { $"{Alert.CLASS_NAME}|all" })" expires-after="@TimeSpan.FromMinutes(60)">
+<cache scoped additional-keys="@(new [] { $"{Alert.CLASS_NAME}|all" })" expires-after="@TimeSpan.FromMinutes(60)">
     <vc:alerts />
-</cache-scope>
+</cache>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,62 @@ public Task<IEnumerable<TreeNode>> GetPagesOnDifferentSiteAsync() {
 }
 ```
 
+## Cache Scope Tag Helper
+
+The tag helper exends the [CacheTagHelper](https://learn.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/built-in/cache-tag-helper?view=aspnetcore-5.0) with the Enabled and ExpireAfter attributes set to a default if not passed.
+
+The Enabled attribute will default to the Preview state of the application, if preview mode is enabled the cache attribute will be disabled.
+
+If the ExpiresAfter attribute is not passed it will default to the Xperience System setting for Server Side Caching found in Settings -> System -> Performance -> Cache content (minutes):
+
+### Example
+```cs
+public class AlertsViewComponent : ViewComponent
+{
+    private readonly IPageRetriever mPageRetriever;
+    private readonly ICacheDependencyBuilderFactory mCacheDependencyBuilderFactory;
+    
+    public AlertsViewComponent(IPageRetriever pageRetriever, ICacheDependencyBuilderFactory cacheDependencyBuilderFactory)
+    {
+        mPageRetriever = pageRetriever;
+        mCacheDependencyBuilderFactory = cacheDependencyBuilderFactory;
+    }
+
+    public async Task<IViewComponentResult> InvokeAsync()
+    {
+        var builder = mCacheDependencyBuilderFactory.Create()
+                        .PagePath("/Alerts", PathTypeEnum.Children);
+
+        var result = await mPageRetriever.RetrieveAsync<Alert>(
+                query => query
+                    .Path("/Alerts", PathTypeEnum.Children)
+                    .OrderBy(nameof(TreeNode.NodeLevel), nameof(TreeNode.NodeOrder)),
+                cacheSettings => cacheSettings.Configure(builder, 60, "GetTabsAsync", "/Alerts")
+        );
+
+        var model = result.Select(AlertViewModel.ToViewModel);
+
+        return View("~/Components/ViewComponents/Alerts/Default.cshtml", model);
+    }
+}
+```
+
+```html 
+<!-- Will add scoped cache dependency keys -->
+<cache-scope>
+    <vc:alerts  />
+</cache-scope>
+<!-- Will add scoped cache dependency keys along with the additional keys passed -->
+<cache-scope additional-keys="@(new [] { $"{Alert.CLASS_NAME}|all" })">
+    <vc:alerts />
+</cache-scope>
+<!-- Will add scoped cache dependency keys along with the additional keys passed and override the expiresafter value from the system settings -->
+<cache-scope additional-keys="@(new [] { $"{Alert.CLASS_NAME}|all" })" expires-after="@TimeSpan.FromMinutes(60)">
+    <vc:alerts />
+</cache-scope>
+```
+
+
 # Other Tools
 ## Cache Durations
 This package comes with 2 Enum Extension methods, `Enum.ToDouble()` and `Enum.ToTimeSpan()`, this converts the `int` value of the enum into a double or timespan (as minutes).  We recommend creating a Cache Duration Enum (ex `CacheMinutesType` ) that has int values corresponding to the minutes you wish to cache for.  This makes changing and managing different 'durations' of caching easy.


### PR DESCRIPTION
Updated Xperience package to refresh one to extend the default Cache Tag Helper to utilize MVCCaching implementation. 